### PR TITLE
Fix path for `lib.es2015` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "files": [
     "dist",
     "lib",
-    "lib/lib.es2015"
+    "lib.es2015"
   ],
   "peerDependencies": {
     "@most/core": "^1.2.3"


### PR DESCRIPTION
I found that the build script generates artifacts in `lib.es2015`, not in `lib/lib.es2015`.
It fixes `package.json` to include `lib.es2015` in published packages.
Thank you.